### PR TITLE
Első óra anyagainak kiegészítése

### DIFF
--- a/docs/homework/01-hw/index.md
+++ b/docs/homework/01-hw/index.md
@@ -9,6 +9,11 @@ A labor célja megismerni a Docker konténerek használatának alapjait és a le
 - A házi leírásban Windows platformot használunk, azonban a feladatok Linuxon és Mac-en is megoldhatóak (a könyvtár elérési útvonalakat megfelelően átírva).
 - Docker Hub login
 - Docker Desktop
+     - <https://www.docker.com/products/docker-desktop/>
+- .NET 8.0
+     - <https://dotnet.microsoft.com/en-us/download/>
+- python
+     - <https://www.python.org/downloads/>
    
     !!! warning
         Más kiépítések, telepítési formák is elérhetőek (pl. Docker Engine), de a Docker Desktop tartalmaz minden eszközt, amire szükségünk lehet. Például `docker init` csak a Docker Desktop-ban van.
@@ -48,6 +53,7 @@ docker --version
 ```
 
 Futtassunk egy egyszerű előre elkészített konténert, ami kiír egy példa szöveget a konzolra.
+Fontos, hogy a telepített Docker Desktop fusson a háttérben!
 
 ```cmd
 docker run hello-world
@@ -131,7 +137,7 @@ Gyakran szeretnénk a host gépről elérni a konténerben lévő fájlokat, vag
 Erre megoldás a _volume_ csatolás, amikor a host gép egy könyvtárát csatoljuk a konténerbe.
 
 !!! danger "NEPTUN"
-    :exclamation: A példákban a `neptun` helyett a **saját neptunkódunkat** helyettesítsük be :exclamation:
+    :exclamation: A példákban a `neptun` helyett a **saját neptunkódunkat** helyettesítsük be. Ha neptun-ként látod, akkor kisbetűvel írd; ha NEPTUN-ként, akkor nagybetűvel :exclamation:
 
 - Hozzunk létre egy munkakönyvtárat tetszőleges helyen a neptun kódunkkal, például `c:\work\neptun` (windows) `~/work/neptun` (linux)
     
@@ -222,7 +228,7 @@ Ehhez a `docker exec` és `docker cp` parancsot használjuk most.
     docker run -d -p 8085:80 nginx
     ```
 
-    Jegyezzük meg a kiírt konténer id-t, alább használni fogjuk.
+    Jegyezzük meg a kiírt konténer id-t, alább használni fogjuk. (A kiírt karakterlánc első 12 karaktere jelöli az ID-t.)
 
 - Futtassunk le egy parancsot a konténerben:
 
@@ -603,6 +609,9 @@ A docker-compose parancsnak nem adtuk meg, hogy milyen yaml fájlból dolgozzon.
 ### Docker init
 
 A `docker init` paranccsal egy megadott technológiához tartozó, docker alapú fejlesztéshez szükséges-hasznos fájlokat generáltathatjuk. A fájlok az adott technológiához illeszkedően készülnek, például ASP .NET Core esetén a megfelelő .NET alap lemezképekre hivatkozik a generált Dockerfile.
+
+ !!! warning ".NET"
+    Előzetesen le kell töltened és telepítened kell a .NET SDK-t!
 
 1. Készíts a repository mappájába egy almappát `aspnetweb` néven. A továbbiakban ennek az új mappának a kontextusában dolgozz.
 


### PR DESCRIPTION
A 0. feladatnál érdemes volna kiírni, hogy a docker –version parancshoz nem, de utána már a konténer futtatásához nem elég előzetesen letölteni a dockert, hanem manuálisan el is kell indítani a docker desktopot, valamint be is kell jelentkezni. Számomra ez nem volt egyértelmű, de azért könnyen rá lehetett jönni. 

1.3 feladatnál a docker run -d -p 8085:80 nginx parancs után nem ír ki konténer id-t. Jobban mondva valamit kiír, aminek az első 12 karaktere az ID, de ezt nem írja a feladat leírása, hogy az volna az.  Ki kell listázni a konténereket, hogy egyértelműen meglássuk. 

A 2.1.5 feladatnál (és még néhány helyen) kizárólag kisbetűs neptun kódok elfogadottak.
4. feladatnál meg kell győződni arról, hogy a .NET SDK telepítve van a számítógépen. Nekem nem volt, de rájöttem gyorsan, hogy ez a baj.  ("Az előkövetelmények" ezt nem tartalmazta. a python-t sem tartalmazza, mint előkövetelmény.  Talán a VSCode programmal együtt települ, de ebben nem vagyok biztos.)

Elnézést kétek, ha nagyon triviális dolgokat vettem észre, de számomra ezek okoztak kisebb megakadásokat és úgy gondoltam, hogy másnak is hasznos lehet.

Szladek Máté
Neptun: TGPZTT
