### PR TITLE
fix typos, bad commands

### DIFF
--- a/docs/homework/02-kubernetes/index.md
+++ b/docs/homework/02-kubernetes/index.md
@@ -369,8 +369,8 @@ Az adatbázisainkat a már megírt YAML leírókkal telepítjük. Ez a leíró f
 
 1. Vizsgáljuk meg a repository `storeapp/hf-kubernetes/db` könyvtárában lévő YAML leírókat.
 
-     - MongoDB: StatefulSet-ként telepítjük, és a perzisztens adattároláshoz dinamikus PersistentVolumeClaim-et használunk
-     - RabbitMQ: StatefulSet-ként telepítjük, és a perzisztens adattároláshoz dinamikus PersistentVolumeClaim-et használunk
+     - MongoDB: StatefulSet-ként telepítjük, Service-en keresztül érhető el és ConfigMap-et használunk
+     - RabbitMQ: StatefulSet-ként telepítjük, és Service-en keresztül érhető el
 
 1. Telepítsük az adatbázisokat:
 


### PR DESCRIPTION
Neptun: WYZJ90

Számomra a következő parancs hibát dobott, így javítottam a hibaüzenet szerint megadott módon
```
❯ kubectl exec -it counter-wyzj90 /bin/bash
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples
```

> MongoDB: StatefulSet-ként telepítjük, és a perzisztens adattároláshoz dinamikus PersistentVolumeClaim-et használunk

Én nem találtam erre utaló részt, de nem vettem ki a szövegből, mert lehet csak én nem találom.

Az annotációból kivett rész, azért vettem ki, mert alatta nem sokkal más módon be kell helyezni, valószínűleg véletlenül maradt ott.
